### PR TITLE
Fix: positional-arg mismatch crashes autoselect_merge_parameters

### DIFF
--- a/src/slay/algorithm.py
+++ b/src/slay/algorithm.py
@@ -126,9 +126,6 @@ def compute_slay_merges(
             sorting_analyzer,
             splitting_probability,
             similarity_type,
-            similarity,
-            ccg_metric,
-            refractory_penalty,
         )
 
     final_metric = compute_final_metric(


### PR DESCRIPTION
## Summary

`compute_slay_merges(..., merge_parameters=\"auto\")` — the default path — always raises `TypeError: only integer scalar arrays can be converted to a scalar index`.

In `algorithm.py:122-132`, the call to `autoselect_merge_parameters` passes `(similarity, ccg_metric, refractory_penalty)` as positional args 4-6. But the callee's signature has `(autoencoder_params, autoencoder, model_path)` in those slots (`autoselect_params.py:20-37`). So:

- the numpy `similarity` array lands in `autoencoder_params`
- the numpy `ccg_metric` array lands in `autoencoder`
- the numpy `refractory_penalty` array lands in `model_path`

`model_path` is then forwarded to `compute_slay_metrics`, which calls `os.path.exists(model_path)` on the numpy array and crashes.

The three extra args were also semantically unnecessary: `autoselect_merge_parameters` recomputes `similarity`/`ccg_metric`/`refractory_penalty` internally on the artificial-split analyzer (`autoselect_params.py:44-55`). Even if they'd been wired to the right parameter names they would have been ignored.

## Fix

Drop the three stray positional args. One-line change.

## Reproduction

```python
import slay
import spikeinterface as si

analyzer = si.load_sorting_analyzer(\"some_analyzer.zarr\")
slay.compute_slay_merges(analyzer)  # merge_parameters defaults to \"auto\"
```

Before this PR: `TypeError: only integer scalar arrays can be converted to a scalar index` inside `os.path.exists`.

After: autoselect runs to completion.

## Test plan

- [x] Repo lacks an existing test suite for the public API. Manual verification on a real ~400-unit SortingAnalyzer succeeded (autoselect runs, returns a parameter dict with `k1`, `k2`, `merge_threshold` keys, downstream `find_merges` proceeds).