### PR TITLE
Fix: size-1 final batch in compute_autoencoder_similarity under NumPy 2

### DIFF
--- a/src/slay/autoencoder.py
+++ b/src/slay/autoencoder.py
@@ -353,13 +353,20 @@ def compute_autoencoder_similarity(
             tqdm(dataloader, desc="Calculating latent representations")
         ):
             spikes, labels, idx = data[0].to(device), data[1].to(device), data[2]
+            # NumPy 2 treats a 1-D torch.Tensor of length 1 as ambiguous with a
+            # 0-D scalar when used as a fancy index, yielding
+            # ``ValueError: setting an array element with a sequence`` on the
+            # last batch whenever ``len(dataset) % batch_size == 1``. Convert
+            # the index tensor to numpy up front — cheap, works in every batch
+            # size, and decouples from torch/numpy array-api quirks.
+            idx_np = idx.cpu().numpy() if isinstance(idx, torch.Tensor) else np.asarray(idx)
 
             reconstructions, _ = autoencoder(spikes)
             loss += loss_fn(spikes, reconstructions).item()
 
             batch_latents = autoencoder.encode(spikes)
-            spike_latents[idx] = batch_latents.cpu().detach().numpy()
-            spike_labels[idx] = labels.cpu().detach().numpy()
+            spike_latents[idx_np] = batch_latents.cpu().detach().numpy()
+            spike_labels[idx_np] = labels.cpu().detach().numpy()
 
     tqdm.write(f"\nAverage Loss: {loss / len(dataloader):.4f}")
 

--- a/src/slay/autoencoder.py
+++ b/src/slay/autoencoder.py
@@ -353,20 +353,16 @@ def compute_autoencoder_similarity(
             tqdm(dataloader, desc="Calculating latent representations")
         ):
             spikes, labels, idx = data[0].to(device), data[1].to(device), data[2]
-            # NumPy 2 treats a 1-D torch.Tensor of length 1 as ambiguous with a
-            # 0-D scalar when used as a fancy index, yielding
-            # ``ValueError: setting an array element with a sequence`` on the
-            # last batch whenever ``len(dataset) % batch_size == 1``. Convert
-            # the index tensor to numpy up front — cheap, works in every batch
-            # size, and decouples from torch/numpy array-api quirks.
-            idx_np = idx.cpu().numpy() if isinstance(idx, torch.Tensor) else np.asarray(idx)
+
+            # convert idx to numpy to handle edge case where batch size = 1
+            idx = idx.cpu().numpy() if isinstance(idx, torch.Tensor) else np.asarray(idx)
 
             reconstructions, _ = autoencoder(spikes)
             loss += loss_fn(spikes, reconstructions).item()
 
             batch_latents = autoencoder.encode(spikes)
-            spike_latents[idx_np] = batch_latents.cpu().detach().numpy()
-            spike_labels[idx_np] = labels.cpu().detach().numpy()
+            spike_latents[idx] = batch_latents.cpu().detach().numpy()
+            spike_labels[idx] = labels.cpu().detach().numpy()
 
     tqdm.write(f"\nAverage Loss: {loss / len(dataloader):.4f}")
 


### PR DESCRIPTION
`compute_slay_merges(...)` crashes on the last DataLoader batch inside `compute_autoencoder_similarity` whenever `len(spike_dataset) % 128 == 1`:

```
TypeError: only 0-dimensional arrays can be converted to Python scalars
ValueError: setting an array element with a sequence.
```

Trigger: `DataLoader(spike_dataset, batch_size=128)` in `compute_autoencoder_similarity` yields batches up to `batch_size`; the tail batch can legitimately be size 1. At that point `idx` (returned by `SpikeDataset.__getitem__` and collated by default_collate) is a 1-D torch tensor of shape `(1,)`. Under NumPy ≥ 2, `numpy_array[torch_tensor_of_shape_(1,)] = numpy_array_of_shape_(1,)` takes a scalar-coerce path and errors. NumPy 1.x accepted it; NumPy 2 tightened fancy-index resolution for objects implementing `__array__`/`__index__`.

Repro (minimal):

```python
import numpy as np, torch
a = np.zeros(4, dtype="int32")
idx = torch.tensor([3], dtype=torch.int64)
a[idx] = np.array([42], dtype="int32")
# ValueError: setting an array element with a sequence.
```

Size-2+ batches work because NumPy reads them unambiguously as 1-D fancy indices.

## Fix

Convert `idx` to numpy before using it as a numpy fancy index. Same conversion pattern already applied to `labels` and `batch_latents` on adjacent lines, so the change is stylistically consistent.

## Repro on a real sorting

Occurred on a 410-unit probe analyzer with 184,962 random spikes → 147,969 train spikes → 1157 batches of 128, last batch = 1. Without the fix: crash after training completes. With the fix: completes cleanly.
